### PR TITLE
Enable VPC features

### DIFF
--- a/src/modules/patterns/lambda/asp_net/main.tf
+++ b/src/modules/patterns/lambda/asp_net/main.tf
@@ -9,6 +9,7 @@ module "lambda" {
   memory_size    = var.memory_size
   timeout        = var.timeout
   variables      = var.variables
+  vpc_config     = var.vpc_config
 
   log_retention_days = var.log_retention_days
 

--- a/src/modules/patterns/lambda/asp_net/variables.tf
+++ b/src/modules/patterns/lambda/asp_net/variables.tf
@@ -60,3 +60,8 @@ variable "tags" {
   type = map(string)
 }
 
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/patterns/lambda/dynamodb_stream_to_sns/main.tf
+++ b/src/modules/patterns/lambda/dynamodb_stream_to_sns/main.tf
@@ -61,6 +61,7 @@ module "app" {
   tags         = var.tags
   memory_size  = 256
   alert_period = var.alert_period
+  vpc_config   = var.vpc_config
 
   max_concurrent_executions = var.max_concurrent_executions
 

--- a/src/modules/patterns/lambda/dynamodb_stream_to_sns/variables.tf
+++ b/src/modules/patterns/lambda/dynamodb_stream_to_sns/variables.tf
@@ -60,3 +60,9 @@ variable "bisect_batch_on_function_error" {
   default     = false
   description = "(Optional) If the function returns an error, split the batch in two and retry. Defaults to false."
 }
+
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/patterns/lambda/scheduled/main.tf
+++ b/src/modules/patterns/lambda/scheduled/main.tf
@@ -9,6 +9,7 @@ module "lambda" {
   memory_size    = var.memory_size
   timeout        = var.timeout
   variables      = var.variables
+  vpc_config     = var.vpc_config
 
   log_retention_days = var.log_retention_days
 

--- a/src/modules/patterns/lambda/scheduled/variables.tf
+++ b/src/modules/patterns/lambda/scheduled/variables.tf
@@ -63,3 +63,8 @@ variable "tags" {
   type = map(string)
 }
 
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/patterns/lambda/with_cw_logs/main.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/main.tf
@@ -69,6 +69,7 @@ module "lambda" {
   timeout        = var.timeout
   variables      = var.variables
   logs_arn       = module.log_group.arn
+  vpc_config     = var.vpc_config
 
   max_concurrent_executions = var.max_concurrent_executions
 

--- a/src/modules/patterns/lambda/with_cw_logs/variables.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/variables.tf
@@ -64,3 +64,8 @@ variable "tags" {
   type = map(string)
 }
 
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/patterns/lambda/with_error_alerts/main.tf
+++ b/src/modules/patterns/lambda/with_error_alerts/main.tf
@@ -10,6 +10,7 @@ module "lambda" {
   memory_size    = var.memory_size
   timeout        = var.timeout
   variables      = var.variables
+  vpc_config     = var.vpc_config
 
   log_retention_days = var.log_retention_days
 

--- a/src/modules/patterns/lambda/with_error_alerts/variables.tf
+++ b/src/modules/patterns/lambda/with_error_alerts/variables.tf
@@ -100,3 +100,8 @@ variable "max_concurrent_executions" {
   description = "(Optional) The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations."
 }
 
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/patterns/security_group/can_access_albelli_networks/main.tf
+++ b/src/modules/patterns/security_group/can_access_albelli_networks/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+module "ranges" {
+  source = "../../../resources/ip_ranges/albelli"
+}
+
+locals {
+  merged_ip_ranges = concat(module.ranges.value, var.extra_ranges)
+}
+
+module "security_group" {
+  source            = "../../../resources/security_group/plain"
+  name              = var.name
+  vpc_id            = var.vpc_id
+  ingress_ip_ranges = local.merged_ip_ranges
+  tags              = var.tags
+}

--- a/src/modules/patterns/security_group/can_access_albelli_networks/outputs.tf
+++ b/src/modules/patterns/security_group/can_access_albelli_networks/outputs.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  value = module.security_group.arn
+}
+
+output "id" {
+  value = module.security_group.id
+}

--- a/src/modules/patterns/security_group/can_access_albelli_networks/variables.tf
+++ b/src/modules/patterns/security_group/can_access_albelli_networks/variables.tf
@@ -1,0 +1,12 @@
+variable "name" {}
+
+variable "vpc_id" {}
+
+variable "extra_ranges" {
+  default = []
+  type    = list(string)
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/src/modules/resources/iam/lambda_to_vpc/main.tf
+++ b/src/modules/resources/iam/lambda_to_vpc/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "aws_iam_policy" "app" {
+  name = var.policy_name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface"
+      ],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}

--- a/src/modules/resources/iam/lambda_to_vpc/outputs.tf
+++ b/src/modules/resources/iam/lambda_to_vpc/outputs.tf
@@ -1,0 +1,5 @@
+output "arn" {
+  value       = aws_iam_policy.app.arn
+  description = "The ARN of the IAM policy"
+}
+

--- a/src/modules/resources/iam/lambda_to_vpc/variables.tf
+++ b/src/modules/resources/iam/lambda_to_vpc/variables.tf
@@ -1,0 +1,2 @@
+variable "policy_name" {
+}

--- a/src/modules/resources/ip_ranges/albelli/main.tf
+++ b/src/modules/resources/ip_ranges/albelli/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+locals {
+  albelli_ranges = [
+    "185.184.204.70/32", # Office AMS
+    "62.97.245.10/32",   # Office BGO
+    "185.184.204.74/32", # Office HAG
+    "62.102.226.22/32",  # Office NLH
+    "89.91.227.16/32",   # Office NLH
+    "213.41.124.76/32",  # Office PAR
+    "77.60.83.148/32",   # Datacenter ALM
+    "62.21.226.193/32",  # Datacenter ALM
+    "192.168.0.0/16",    # Internal Network
+    "10.0.0.0/8",        # Internal Network
+    "172.16.0.0/12",     # Internal Network
+  ]
+}

--- a/src/modules/resources/ip_ranges/albelli/outputs.tf
+++ b/src/modules/resources/ip_ranges/albelli/outputs.tf
@@ -1,0 +1,3 @@
+output "value" {
+  value = local.albelli_ranges
+}

--- a/src/modules/resources/lambda/plain/main.tf
+++ b/src/modules/resources/lambda/plain/main.tf
@@ -4,6 +4,8 @@ locals {
 
 locals {
   resolve_bucket_path = var.s3_bucket_path == null ? "builds/lambda/${var.name}/lambda.zip" : var.s3_bucket_path
+
+  vpc_config = var.vpc_config == null ? [] : toset([var.vpc_config])
 }
 
 resource "aws_lambda_function" "app" {
@@ -19,6 +21,15 @@ resource "aws_lambda_function" "app" {
   timeout       = var.timeout
 
   reserved_concurrent_executions = var.max_concurrent_executions
+
+  dynamic "vpc_config" {
+    for_each = local.vpc_config
+
+    content {
+      subnet_ids         = vpc_config.value.subnet_ids
+      security_group_ids = vpc_config.value.security_group_ids
+    }
+  }
 
   environment {
     variables = var.variables

--- a/src/modules/resources/lambda/plain/variables.tf
+++ b/src/modules/resources/lambda/plain/variables.tf
@@ -69,3 +69,8 @@ variable "tags" {
   type = map(string)
 }
 
+variable "vpc_config" {
+  description = "VPC Config for the Lambda function"
+  type        = map
+  default     = null
+}

--- a/src/modules/resources/security_group/plain/main.tf
+++ b/src/modules/resources/security_group/plain/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "aws_security_group" "app" {
+  name   = var.name
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = var.ingress_ip_ranges
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = var.egress_ip_ranges
+  }
+
+  tags = var.tags
+}

--- a/src/modules/resources/security_group/plain/outputs.tf
+++ b/src/modules/resources/security_group/plain/outputs.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  value = aws_security_group.app.arn
+}
+
+output "id" {
+  value = aws_security_group.app.id
+}

--- a/src/modules/resources/security_group/plain/variables.tf
+++ b/src/modules/resources/security_group/plain/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {}
+
+variable "vpc_id" {}
+
+variable "ingress_ip_ranges" {
+  default = ["0.0.0.0/0"]
+}
+
+variable "egress_ip_ranges" {
+  default = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  type = map(string)
+}

--- a/src/test.tf
+++ b/src/test.tf
@@ -17,6 +17,27 @@ module "label" {
   team        = "customer care technology"
 }
 
+data "aws_vpc" "main" {
+  tags = {
+    Name = "sandbox_vpc"
+  }
+}
+
+data "aws_subnet_ids" "private" {
+  vpc_id = data.aws_vpc.main.id
+
+  tags = {
+    Name = "private-*"
+  }
+}
+module "security_group" {
+  source       = "./modules/patterns/security_group/can_access_albelli_networks"
+  name         = module.label.id_without_env
+  vpc_id       = data.aws_vpc.main.id
+  extra_ranges = ["213.127.62.87/32"]
+  tags         = module.label.tags
+}
+
 module "test" {
   source              = "./modules/patterns/lambda/scheduled"
   name                = module.label.id_without_env
@@ -30,6 +51,11 @@ module "test" {
   variables = {
     env1 = "var1"
     env2 = "var2"
+  }
+
+  vpc_config = {
+    subnet_ids         = data.aws_subnet_ids.private.ids
+    security_group_ids = [module.security_group.id]
   }
 
   tags = module.label.tags
@@ -50,4 +76,3 @@ output "out2" {
 output "out3" {
   value = module.test.role_name
 }
-


### PR DESCRIPTION
- Enable VPC config in ALL lambda patterns
- Persist https://wiki.albelli.net/wiki/Albelli_IP_Ranges in TF modules (src\modules\resources\ip_ranges\albelli)
- Added plain security group
- Added security group to access Albelli networks
- Added IAM policy for lambda to access VPC