### PR TITLE
Major release 4.0, Breaking changes, mostly defaults

### DIFF
--- a/src/modules/patterns/lambda/asp_net/variables.tf
+++ b/src/modules/patterns/lambda/asp_net/variables.tf
@@ -17,7 +17,7 @@ variable "s3_bucket_path" {
 }
 
 variable "runtime" {
-  default     = "dotnetcore2.1"
+  default     = "dotnetcore3.1"
   description = "The identifier of the function's runtime."
 }
 
@@ -32,7 +32,7 @@ variable "memory_size" {
 }
 
 variable "timeout" {
-  default     = "30"
+  default     = "29"
   description = "The amount of time your Lambda Function has to run in seconds."
 }
 
@@ -47,7 +47,7 @@ variable "variables" {
 variable "log_retention_days" {
   type        = string
   description = "Cloudwatch logs retention"
-  default     = "30"
+  default     = "7"
 }
 
 variable "domain" {

--- a/src/modules/patterns/lambda/dynamodb_stream_to_sns/main.tf
+++ b/src/modules/patterns/lambda/dynamodb_stream_to_sns/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 locals {
   sourceFile          = "${path.module}/index.js"
   adapterArtifactPath = "${path.cwd}/publish/package.zip"
@@ -55,7 +59,7 @@ module "app" {
   name         = var.name
   filepath     = local.adapterArtifactPath
   handler      = "index.handler"
-  runtime      = "nodejs10.x"
+  runtime      = "nodejs12.x"
   emails       = var.emails
   description  = var.description
   tags         = var.tags
@@ -89,4 +93,3 @@ resource "aws_lambda_event_source_mapping" "app" {
     }
   }
 }
-

--- a/src/modules/patterns/lambda/dynamodb_stream_to_sns/versions.tf
+++ b/src/modules/patterns/lambda/dynamodb_stream_to_sns/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/patterns/lambda/scheduled/main.tf
+++ b/src/modules/patterns/lambda/scheduled/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 module "lambda" {
   source         = "../with_cw_logs"
   name           = var.name
@@ -35,4 +39,3 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.schedule.arn
 }
-

--- a/src/modules/patterns/lambda/scheduled/variables.tf
+++ b/src/modules/patterns/lambda/scheduled/variables.tf
@@ -17,7 +17,7 @@ variable "s3_bucket_path" {
 }
 
 variable "runtime" {
-  default     = "dotnetcore2.1"
+  default     = "dotnetcore3.1"
   description = "The identifier of the function's runtime."
 }
 
@@ -47,11 +47,11 @@ variable "variables" {
 variable "log_retention_days" {
   type        = string
   description = "Cloudwatch logs retention"
-  default     = "30"
+  default     = "7"
 }
 
 variable "max_concurrent_executions" {
-  default     = -1
+  default     = 1
   description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations."
 }
 

--- a/src/modules/patterns/lambda/scheduled/versions.tf
+++ b/src/modules/patterns/lambda/scheduled/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/patterns/lambda/with_cw_logs/main.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 resource "aws_iam_role" "app" {
   name        = var.name
   description = var.description

--- a/src/modules/patterns/lambda/with_cw_logs/main.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/main.tf
@@ -21,6 +21,7 @@ resource "aws_iam_role" "app" {
 }
 EOF
 
+  tags = var.tags
 }
 
 module "log_group" {

--- a/src/modules/patterns/lambda/with_cw_logs/variables.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/variables.tf
@@ -22,7 +22,7 @@ variable "s3_bucket_path" {
 }
 
 variable "runtime" {
-  default     = "dotnetcore2.1"
+  default     = "dotnetcore3.1"
   description = "The identifier of the function's runtime."
 }
 
@@ -52,7 +52,7 @@ variable "variables" {
 variable "log_retention_days" {
   type        = string
   description = "Cloudwatch logs retention"
-  default     = "30"
+  default     = "7"
 }
 
 variable "max_concurrent_executions" {

--- a/src/modules/patterns/lambda/with_cw_logs/versions.tf
+++ b/src/modules/patterns/lambda/with_cw_logs/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/patterns/lambda/with_error_alerts/main.tf
+++ b/src/modules/patterns/lambda/with_error_alerts/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 module "lambda" {
   source         = "../with_cw_logs"
   name           = var.name

--- a/src/modules/patterns/lambda/with_error_alerts/variables.tf
+++ b/src/modules/patterns/lambda/with_error_alerts/variables.tf
@@ -33,7 +33,7 @@ variable "emails" {
 }
 
 variable "runtime" {
-  default     = "dotnetcore2.1"
+  default     = "dotnetcore3.1"
   description = "(Optional) The identifier of the function's runtime."
 }
 
@@ -43,7 +43,7 @@ variable "description" {
 }
 
 variable "memory_size" {
-  default     = "512"
+  default     = "128"
   description = "(Optional) Amount of memory in MB your Lambda Function can use at runtime."
 }
 
@@ -91,7 +91,7 @@ variable "threshold" {
 }
 
 variable "log_retention_days" {
-  default     = "30"
+  default     = "7"
   description = "(Optional) Cloudwatch logs retention."
 }
 

--- a/src/modules/patterns/lambda/with_error_alerts/versions.tf
+++ b/src/modules/patterns/lambda/with_error_alerts/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
@@ -27,6 +27,6 @@ resource "aws_sns_topic_subscription" "topic_subscription" {
   protocol  = "sqs"
   endpoint  = module.queue.arn
   
-  raw_message_delivery = true
+  raw_message_delivery = var.raw_message_delivery
 }
 

--- a/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 module "queue" {
   source                     = "../sqs_with_dlq"
   name                       = var.name
@@ -21,5 +25,7 @@ resource "aws_sns_topic_subscription" "topic_subscription" {
   topic_arn = module.topic.arn
   protocol  = "sqs"
   endpoint  = module.queue.arn
+  
+  raw_message_delivery = true
 }
 

--- a/src/modules/patterns/sns_to_sqs_with_dlq/variables.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/variables.tf
@@ -44,3 +44,8 @@ variable "dlq_suffix" {
   default     = "-ERROR"
   description = "The dead letter queue name suffix"
 }
+
+variable "raw_message_delivery" {
+  default     = true
+  description = "Boolean indicating whether or not to enable raw message delivery (the original message is directly passed, not wrapped in JSON with the original message in the message property)."
+}

--- a/src/modules/patterns/sns_to_sqs_with_dlq/versions.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/patterns/sqs_with_dlq/main.tf
+++ b/src/modules/patterns/sqs_with_dlq/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 module "dlq" {
   source                     = "../../resources/sqs/plain"
   name                       = "${var.name}-ERROR"
@@ -36,14 +40,6 @@ data "aws_iam_policy_document" "queue_policy" {
       "sqs:SendMessage",
     ]
 
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibility in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
     resources = [module.queue.arn]
   }
 }
@@ -52,4 +48,3 @@ resource "aws_sqs_queue_policy" "queue_policy" {
   queue_url = module.queue.id
   policy    = data.aws_iam_policy_document.queue_policy.json
 }
-

--- a/src/modules/patterns/sqs_with_dlq/variables.tf
+++ b/src/modules/patterns/sqs_with_dlq/variables.tf
@@ -39,4 +39,3 @@ variable "policy" {
 variable "tags" {
   type = map(string)
 }
-

--- a/src/modules/patterns/sqs_with_dlq/versions.tf
+++ b/src/modules/patterns/sqs_with_dlq/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/resources/label/main.tf
+++ b/src/modules/resources/label/main.tf
@@ -1,12 +1,16 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 locals {
-  id = join(
+  id_with_env = join(
     var.delimiter,
     compact(
       concat([var.application, var.name, var.environment], var.attributes),
     ),
   )
 
-  id_without_env = join(
+  id = join(
     var.delimiter,
     compact(concat([var.application, var.name], var.attributes)),
   )

--- a/src/modules/resources/label/outputs.tf
+++ b/src/modules/resources/label/outputs.tf
@@ -1,15 +1,20 @@
 output "id" {
   value       = local.id
-  description = "Disambiguated ID"
+  description = "Fixed ID for static names (e.g. lambda name)"
 }
 
+// NOTE: still here for backward compatibility, can be removed next major release
 output "id_without_env" {
-  value       = local.id_without_env
+  value       = local.id
   description = "Fixed ID for static names (e.g. lambda name)"
+}
+
+output "id_env" {
+  value       = local.id_with_env
+  description = "Disambiguated ID"
 }
 
 output "tags" {
   value       = local.tags
   description = "Normalized Tag map"
 }
-

--- a/src/modules/resources/label/versions.tf
+++ b/src/modules/resources/label/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}

--- a/src/modules/resources/lambda/plain/main.tf
+++ b/src/modules/resources/lambda/plain/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 locals {
   resolve_s3_key = var.filepath == null ? local.resolve_bucket_path : null
 }

--- a/src/modules/resources/lambda/plain/versions.tf
+++ b/src/modules/resources/lambda/plain/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}


### PR DESCRIPTION
Breaking changes:

- default runtime for lambdas upgraded from `dotnetcore2.1` to `dotnetcore3.1`
- Node JS lambda (DynamoDB stream to SNS) runtime upgraded from `nodejs10.x` to `nodejs12.x`
- Label: **DO NOT USE ENV in resource names**. Label outputs changed to do not use env in the name by default (output.id). output.id_without_env is still there, but will be deleted next major release. output.id_env added if someone still needs it.
- Lambda API pattern timeout was decreased from 30 to 29 seconds to be the same as API Gateway restriction
- CW logs retention default period decreased from 30 to 7 days
- SNS to SQS pattern uses `raw_message_delivery` by default