### PR TITLE
Allow custom suffix for DLQ

### DIFF
--- a/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/main.tf
@@ -1,6 +1,7 @@
 module "queue" {
   source                     = "../sqs_with_dlq"
   name                       = var.name
+  dlq_suffix                 = var.dlq_suffix
   visibility_timeout_seconds = var.visibility_timeout_seconds
   message_retention_seconds  = var.message_retention_seconds
   max_message_size           = var.max_message_size

--- a/src/modules/patterns/sns_to_sqs_with_dlq/variables.tf
+++ b/src/modules/patterns/sns_to_sqs_with_dlq/variables.tf
@@ -40,3 +40,7 @@ variable "tags" {
   type = map(string)
 }
 
+variable "dlq_suffix" {
+  default     = "-ERROR"
+  description = "The dead letter queue name suffix"
+}

--- a/src/modules/patterns/sqs_with_dlq/main.tf
+++ b/src/modules/patterns/sqs_with_dlq/main.tf
@@ -1,6 +1,6 @@
 module "dlq" {
   source                     = "../../resources/sqs/plain"
-  name                       = "${var.name}-ERROR"
+  name                       = "${var.name}${var.dlq_suffix}"
   visibility_timeout_seconds = var.visibility_timeout_seconds
   tags                       = var.tags
 

--- a/src/modules/patterns/sqs_with_dlq/variables.tf
+++ b/src/modules/patterns/sqs_with_dlq/variables.tf
@@ -40,3 +40,7 @@ variable "tags" {
   type = map(string)
 }
 
+variable "dlq_suffix" {
+  default     = "-ERROR"
+  description = "The dead letter queue name suffix"
+}


### PR DESCRIPTION
Our naming standards require -DLQ instead of -ERROR